### PR TITLE
added the CircShiftedArray code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.7"
+          version: "1.11"
       - uses: julia-actions/julia-docdeploy@releases/v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -16,9 +16,10 @@ Adapt = "3.7, 4.0, 4.1"
 julia = "1.9, 1.10, 1.11"
 
 [extras]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [targets]
-test = ["Test", "CUDA", "Adapt"]
+test = ["Test", "AbstractFFTs", "CUDA", "Adapt"]

--- a/README.md
+++ b/README.md
@@ -3,18 +3,15 @@
 |:---------------------------------------:|:-----------------------------------------:|:-------------------------------:|
 | [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![][CI-img]][CI-url] | [![][codecov-img]][codecov-url] |
 
-
 # MutableShiftedArrays.jl
-A lightweight toolbox representing a ShiftedArray which is mutable. The code was based on `ShiftedArrays.jl`.
-Via the extension mechanism, `CUDA.jl` support is provided both for mutating and non-mutating operations.
+A lightweight toolbox representing a ShiftedArray which is mutable. The code was based on (`ShiftedArrays.jl`)[https://github.com/JuliaArrays/ShiftedArrays.jl] by Pietro Vertechi et al..
+Via the extension mechanism, `CUDA.jl` support is provided both for mutating and non-mutating operations for the `MutableShiftedArray` type as well as `CircShiftedArray`.
 
 The type `MutableShiftedArray` also supports having a modifies size of the view. This is useful for region of interest views, which can even
 surpass the limit of the original array.
 Mutations to elements outside the boundary of the original array are silently ignored and the `default` value is returned upon subsequent read operations.
 
 This code and most of the documentation is based on https://github.com/JuliaArrays/ShiftedArrays.jl with contributers listed below.
-
-The other toolbox also supports `CircShiftedArray` and `fftshift`.
 
 ## Contributors
 - **Pietro Vertechi** - [piever](https://github.com/piever)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,6 +5,8 @@
 ```@docs
 MutableShiftedArray
 MutableShiftedVector
+CircShiftedArray
+CircShiftedVector
 ```
 
 ## Shifting operations
@@ -12,6 +14,9 @@ MutableShiftedVector
 ```@docs
 MutableShiftedArrays.lag
 MutableShiftedArrays.lead
+MutableShiftedArrays.fftshift
+MutableShiftedArrays.ifftshift
+MutableShiftedArrays.circshift
 ```
 
 ## Accessor functions
@@ -19,6 +24,7 @@ MutableShiftedArrays.lead
 ```@docs
 shifts
 default
+MutableShiftedArrays.ft_center_diff
 ```
 
 ## Internals

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -3,8 +3,8 @@ using CUDA
 using Adapt
 using MutableShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
-MutableShiftedArrayCu{N, CD} = MutableShiftedArray{<:Any,<:Any,<:Any,<:CuArray{<:Any,N,CD}}
-MutableShiftedArrayOrWrapped = Union{MutableShiftedArray,
+const MutableShiftedArrayCu{N, CD} = MutableShiftedArray{<:Any,<:Any,<:Any,<:CuArray{<:Any,N,CD}}
+const MutableShiftedArrayOrWrapped = Union{MutableShiftedArray,
                                     Base.ReshapedArray{<:Any, <:Any, <:MutableShiftedArray},
                                     SubArray{<:Any, <:Any, <:MutableShiftedArray, <:Any, <:Any}}
 
@@ -15,7 +15,7 @@ Adapt.parent_type(::Type{MutableShiftedArray{_A,_B,_C,AA}}) where {_A,_B,_C,AA} 
 Adapt.unwrap_type(W::Type{<:MutableShiftedArray}) = unwrap_type(parent_type(W))
 
 # function Base.Broadcast.BroadcastStyle(::Type{T})  where {N, CD, T<:MutableShiftedArraySubCu{N, CD}}
-function Base.Broadcast.BroadcastStyle(W::Type{<:MutableShiftedArrayOrWrapped})
+function Base.Broadcast.BroadcastStyle(W::Type{<:MutableShiftedArrayOrWrapped}) 
     return Base.Broadcast.BroadcastStyle(unwrap_type(W))
 end
 
@@ -42,6 +42,88 @@ end
 
 function Base.:(==)(x::T, y::T)  where {N, CD, T<:MutableShiftedArrayCu{N,CD}}    
     return all(x .== y)
+end
+
+####### code for CircShiftedArray
+
+get_base_arr(arr::CuArray) = arr
+get_base_arr(arr::Array) = arr
+function get_base_arr(arr::AbstractArray) 
+    p = parent(arr)
+    return (p === arr) ? arr : get_base_arr(parent(arr))
+end
+
+# define a number of Union types to not repeat all definitions for each type
+const AllShiftedType = MutableShiftedArrays.CircShiftedArray{<:Any,<:Any,<:Any}
+
+# these are special only if a CuArray is wrapped
+
+const AllSubArrayType = Union{SubArray{<:Any, <:Any, <:AllShiftedType, <:Any, <:Any},
+                        Base.ReshapedArray{<:Any, <:Any, <:AllShiftedType, <:Any},
+                        SubArray{<:Any, <:Any, <:Base.ReshapedArray{<:Any, <:Any, <:AllShiftedType, <:Any}, <:Any, <:Any}}
+const AllShiftedAndViews = Union{AllShiftedType, AllSubArrayType}
+
+const AllShiftedTypeCu{N, CD} = MutableShiftedArrays.CircShiftedArray{<:Any,<:Any,<:CuArray{<:Any,N,CD}}
+const AllSubArrayTypeCu{N, CD} = Union{SubArray{<:Any, <:Any, <:AllShiftedTypeCu{N,CD}, <:Any, <:Any},
+                                 Base.ReshapedArray{<:Any, <:Any, <:AllShiftedTypeCu{N,CD}, <:Any},
+                                 SubArray{<:Any, <:Any, <:Base.ReshapedArray{<:Any, <:Any, <:AllShiftedTypeCu{N,CD}, <:Any}, <:Any, <:Any}}
+const AllShiftedAndViewsCu{N, CD} = Union{AllShiftedTypeCu{N, CD}, AllSubArrayTypeCu{N, CD}}
+
+Adapt.adapt_structure(to, x::MutableShiftedArrays.CircShiftedArray{T, N, S}) where {T, N, S} = MutableShiftedArrays.CircShiftedArray(adapt(to, parent(x)), MutableShiftedArrays.shifts(x));
+
+function Base.Broadcast.BroadcastStyle(::Type{T})  where {N, CD, T<:AllShiftedTypeCu{N, CD}}
+    CUDA.CuArrayStyle{N,CD}()
+end
+
+# Define the BroadcastStyle for SubArray of MutableShiftedArray with CuArray
+
+function Base.Broadcast.BroadcastStyle(::Type{T})  where {N, CD, T<:AllSubArrayTypeCu{N, CD}}
+    CUDA.CuArrayStyle{N,CD}()
+end
+
+function Base.copy(s::AllShiftedAndViews)
+    res = similar(get_base_arr(s), eltype(s), size(s));
+    res .= s
+    return res
+end
+
+function Base.collect(x::AllShiftedAndViews) 
+    return copy(x) # stay on the GPU        
+end
+
+function Base.Array(x::AllShiftedAndViews) 
+    return Array(copy(x)) # remove from GPU
+end
+
+function Base.:(==)(x::AllShiftedAndViewsCu, y::AbstractArray) 
+    return all(x .== y)
+end
+
+function Base.:(==)(y::AbstractArray, x::AllShiftedAndViewsCu) 
+    return all(x .== y)
+end
+
+function Base.:(==)(x::AllShiftedAndViewsCu, y::AllShiftedAndViewsCu) 
+    return all(x .== y)
+end
+
+function Base.isapprox(x::AllShiftedAndViewsCu, y::AbstractArray; atol=0, rtol=atol>0 ? 0 : sqrt(eps(real(eltype(x)))), va...) 
+    atol = (atol != 0) ? atol : rtol * maximum(abs.(x))
+    return all(abs.(x .- y) .<= atol)
+end
+
+function Base.isapprox(y::AbstractArray, x::AllShiftedAndViewsCu; atol=0, rtol=atol>0 ? 0 : sqrt(eps(real(eltype(x)))),  va...)     
+    atol = (atol != 0) ? atol : rtol * maximum(abs.(x))
+    return all(abs.(x .- y) .<= atol)
+end
+
+function Base.isapprox(x::AllShiftedAndViewsCu, y::AllShiftedAndViewsCu; atol=0, rtol=atol>0 ? 0 : sqrt(eps(real(eltype(x)))),  va...) # where {CT, N, CD, T<:ShiftedArrays.CircShiftedArray{<:Any,<:Any,<:CuArray{CT,N,CD}}}    
+    atol = (atol != 0) ? atol : rtol * maximum(abs.(x))
+    return all(abs.(x .- y) .<= atol)
+end
+
+function Base.show(io::IO, mm::MIME"text/plain", cs::AllShiftedAndViews) 
+    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
 end
 
 end

--- a/licences/LICENSE.md
+++ b/licences/LICENSE.md
@@ -1,0 +1,9 @@
+The ShiftedArrays.jl package is licensed under the MIT "Expat" License:
+
+Copyright (c) 2018: Pietro Vertechi.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licences/README.md
+++ b/licences/README.md
@@ -1,0 +1,6 @@
+# Licences
+This toolbox builds on (`ShiftedArrays.jl`)[https://github.com/JuliaArrays/ShiftedArrays.jl] and is largely compatible with it. However, the `MutableShiftedArray` type supports mutating the lazily shifted array
+The `CircShiftedArray` type is currentyl identical to the one present in `ShiftedArrays.jl`, but extended (see `ext` folder) by supporting also the `CuArray` type as defined in the `CUDA.jl` toolbox.
+
+For completeness this `licence` folder contains the original licence of `ShiftedArrays.jl`, which applies to the code in `circshift.jl`.
+

--- a/src/MutableShiftedArrays.jl
+++ b/src/MutableShiftedArrays.jl
@@ -1,11 +1,17 @@
 module MutableShiftedArrays
+# Note that the CircShiftedArray is code copied directly from ShiftedArrays.jl
+# This is since the CUDASupportExt was not supported in ShiftedArrays.jl
 
 import Base: fill!, checkbounds, getindex, setindex!, parent, size, axes, similar, copy, collect
 export shifts, default, get_src_dst_ranges
 export MutableShiftedArray, MutableShiftedVector
+export CircShiftedArray, CircShiftedVector
 
 include("utils.jl")
 include("mutableshiftedarray.jl")
+include("circshiftedarray.jl")
 include("lag.jl")
+include("circshift.jl")
+include("fftshift.jl")
 
 end # module MutableShiftedArrays

--- a/src/circshift.jl
+++ b/src/circshift.jl
@@ -1,0 +1,31 @@
+"""
+    circshift(v::AbstractArray, n)
+
+Return a `CircShiftedArray` object which lazily represents the array `v` shifted
+circularly by `n` (an `Integer` or a `Tuple` of `Integer`s).
+If the number of dimensions of `v` exceeds the length of `n`, the shift in the
+remaining dimensions is assumed to be `0`.
+
+# Examples
+
+```jldoctest circshift
+julia> v = [1, 3, 5, 4];
+
+julia> MutableShiftedArrays.circshift(v, 1)
+4-element CircShiftedVector{Int64, Vector{Int64}}:
+ 4
+ 1
+ 3
+ 5
+
+julia> w = reshape(1:16, 4, 4);
+
+julia> MutableShiftedArrays.circshift(w, (1, -1))
+4×4 CircShiftedArray{Int64, 2, Base.ReshapedArray{Int64, 2, UnitRange{Int64}, Tuple{}}}:
+ 8  12  16  4
+ 5   9  13  1
+ 6  10  14  2
+ 7  11  15  3
+```
+"""
+circshift(v::AbstractArray, n) = CircShiftedArray(v, n)

--- a/src/circshiftedarray.jl
+++ b/src/circshiftedarray.jl
@@ -1,0 +1,85 @@
+"""
+    CircShiftedArray(parent::AbstractArray, shifts)
+
+Custom `AbstractArray` object to store an `AbstractArray` `parent` circularly shifted
+by `shifts` steps (where `shifts` is a `Tuple` with one `shift` value per dimension of `parent`).
+Use `copy` to collect the values of a `CircShiftedArray` into a normal `Array`.
+
+!!! note
+    `shift` is modified with a modulo operation and does not store the passed value
+    but instead a nonnegative number which leads to an equivalent shift.
+
+!!! note
+    If `parent` is itself a `CircShiftedArray`, the constructor does not nest
+    `CircShiftedArray` objects but rather combines the shifts additively.
+
+# Examples
+
+```jldoctest circshiftedarray
+julia> v = [1, 3, 5, 4];
+
+julia> s = CircShiftedArray(v, (1,))
+4-element CircShiftedVector{Int64, Vector{Int64}}:
+ 4
+ 1
+ 3
+ 5
+
+julia> copy(s)
+4-element Vector{Int64}:
+ 4
+ 1
+ 3
+ 5
+```
+"""
+struct CircShiftedArray{T, N, S<:AbstractArray} <: AbstractArray{T, N}
+    parent::S
+    # the field `shifts` stores the circular shifts modulo the size of the parent array
+    shifts::NTuple{N, Int}
+    function CircShiftedArray(p::AbstractArray{T, N}, n = ()) where {T, N}
+        shifts = map(mod, padded_tuple(p, n), size(p))
+        return new{T, N, typeof(p)}(p, shifts)
+    end
+end
+
+function CircShiftedArray(c::CircShiftedArray, n = ())
+    shifts = map(+, MutableShiftedArrays.shifts(c), padded_tuple(c, n))
+    return CircShiftedArray(parent(c), shifts)
+end
+
+"""
+    CircShiftedVector{T, S<:AbstractArray}
+
+Shorthand for `CircShiftedArray{T, 1, S}`.
+"""
+const CircShiftedVector{T, S<:AbstractArray} = CircShiftedArray{T, 1, S}
+
+CircShiftedVector(v::AbstractVector, n = ()) = CircShiftedArray(v, n)
+
+size(s::CircShiftedArray) = size(parent(s))
+axes(s::CircShiftedArray) = axes(parent(s))
+
+@inline function getindex(s::CircShiftedArray{T, N}, x::Vararg{Int, N}) where {T, N}
+    @boundscheck checkbounds(s, x...)
+    v, ind = parent(s), offset(shifts(s), x)
+    i = map(bringwithin, ind, axes(s))
+    return @inbounds v[i...]
+end
+
+@inline function setindex!(s::CircShiftedArray{T, N}, el, x::Vararg{Int, N}) where {T, N}
+    @boundscheck checkbounds(s, x...)
+    v, ind = parent(s), offset(shifts(s), x)
+    i = map(bringwithin, ind, axes(s))
+    @inbounds v[i...] = el
+    return s
+end
+
+parent(s::CircShiftedArray) = s.parent
+
+"""
+    shifts(s::CircShiftedArray)
+
+Return amount by which `s` is shifted compared to `parent(s)`.
+"""
+shifts(s::CircShiftedArray) = s.shifts

--- a/src/fftshift.jl
+++ b/src/fftshift.jl
@@ -1,0 +1,83 @@
+"""
+    ft_center_diff(s [, dims])
+
+Return the shifts required to center dimensions `dims` at the respective
+Fourier centers.
+This function is internally used by [`MutableShiftedArrays.fftshift`](@ref) and
+[`MutableShiftedArrays.ifftshift`](@ref).
+
+# Examples
+
+```jldoctest
+julia> MutableShiftedArrays.ft_center_diff((4, 5, 6), (1, 2)) # Fourier center is at (2, 3, 0)
+(2, 2, 0)
+
+julia> MutableShiftedArrays.ft_center_diff((4, 5, 6), (1, 2, 3)) # Fourier center is at (2, 3, 4)
+(2, 2, 3)
+```
+"""
+function ft_center_diff(s::NTuple{N, T}, dims=ntuple(identity, Val(N))) where {N, T}
+    return ntuple(i -> i ∈ dims ?  s[i] ÷ 2 : 0, N)
+end
+
+"""
+    fftshift(x [, dims])
+
+Lazy version of `AbstractFFTs.fftshift(x, dims)`. Return a `CircShiftedArray`
+where each given dimension is shifted by `N÷2`, where `N` is the size of
+that dimension.
+
+# Examples
+
+```jldoctest
+julia> MutableShiftedArrays.fftshift([1 0 0 0])
+1×4 CircShiftedArray{Int64, 2, Matrix{Int64}}:
+ 0  0  1  0
+
+julia> MutableShiftedArrays.fftshift([1 0 0; 0 0 0; 0 0 0])
+3×3 CircShiftedArray{Int64, 2, Matrix{Int64}}:
+ 0  0  0
+ 0  1  0
+ 0  0  0
+
+julia> MutableShiftedArrays.fftshift([1 0 0; 0 0 0; 0 0 0], (1,))
+3×3 CircShiftedArray{Int64, 2, Matrix{Int64}}:
+ 0  0  0
+ 1  0  0
+ 0  0  0
+```
+"""
+function fftshift(x::AbstractArray{T, N}, dims=ntuple(identity, Val(N))) where {T, N}
+    return MutableShiftedArrays.circshift(x, ft_center_diff(size(x), dims))
+end
+
+"""
+    ifftshift(x [, dims])
+
+Lazy version of `AbstractFFTs.ifftshift(x, dims)`. Return a `CircShiftedArray`
+where each given dimension is shifted by `-N÷2`, where `N` is the size of
+that dimension.
+
+# Examples
+
+```jldoctest
+julia> MutableShiftedArrays.ifftshift([0 0 1 0])
+1×4 CircShiftedArray{Int64, 2, Matrix{Int64}}:
+ 1  0  0  0
+
+julia> MutableShiftedArrays.ifftshift([0 0 0; 0 1 0; 0 0 0])
+3×3 CircShiftedArray{Int64, 2, Matrix{Int64}}:
+ 1  0  0
+ 0  0  0
+ 0  0  0
+
+julia> MutableShiftedArrays.ifftshift([0 1 0; 0 0 0; 0 0 0], (2,))
+3×3 CircShiftedArray{Int64, 2, Matrix{Int64}}:
+ 1  0  0
+ 0  0  0
+ 0  0  0
+```
+"""
+function ifftshift(x::AbstractArray{T, N}, dims=ntuple(identity, Val(N))) where {T, N}
+    return MutableShiftedArrays.circshift(x, map(-, ft_center_diff(size(x), dims)))
+end


### PR DESCRIPTION
added the `CircShiftedArrays.jl` code from the `ShiftedArrays.jl` toolbox and its extension support. The Extension code is somewhat heterogenous, which could potentially be unified. 
